### PR TITLE
Add 1.8 support

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/ProtocolConstants.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/ProtocolConstants.java
@@ -3,6 +3,7 @@ package com.velocitypowered.proxy.protocol;
 import java.util.Arrays;
 
 public enum ProtocolConstants { ;
+    public static final int MINECRAFT_1_8 = 47;
     public static final int MINECRAFT_1_9 = 107;
     public static final int MINECRAFT_1_9_1 = 108;
     public static final int MINECRAFT_1_9_2 = 109;
@@ -15,9 +16,10 @@ public enum ProtocolConstants { ;
     public static final int MINECRAFT_1_12_2 = 340;
     public static final int MINECRAFT_1_13 = 393;
 
-    public static final int MINIMUM_GENERIC_VERSION = MINECRAFT_1_9;
+    public static final int MINIMUM_GENERIC_VERSION = MINECRAFT_1_8;
 
     public static final int[] SUPPORTED_VERSIONS = new int[] {
+            MINECRAFT_1_8,
             MINECRAFT_1_9,
             MINECRAFT_1_9_1,
             MINECRAFT_1_9_2,

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
@@ -32,21 +32,25 @@ public enum StateRegistry {
     PLAY {
         {
             SERVERBOUND.register(Chat.class, Chat::new,
+                    map(0x01, MINECRAFT_1_8),
                     map(0x02, MINECRAFT_1_9),
                     map(0x03, MINECRAFT_1_12),
                     map(0x02, MINECRAFT_1_12_2),
                     map(0x02, MINECRAFT_1_13));
             SERVERBOUND.register(ClientSettings.class, ClientSettings::new,
+                    map(0x15, MINECRAFT_1_8),
                     map(0x04, MINECRAFT_1_9),
                     map(0x05, MINECRAFT_1_12),
                     map(0x04, MINECRAFT_1_12_1),
                     map(0x04, MINECRAFT_1_13));
             SERVERBOUND.register(PluginMessage.class, PluginMessage::new,
+                    map(0x17, MINECRAFT_1_8),
                     map(0x09, MINECRAFT_1_9),
                     map(0x0A, MINECRAFT_1_12),
                     map(0x09, MINECRAFT_1_12_1),
                     map(0x0A, MINECRAFT_1_13));
             SERVERBOUND.register(KeepAlive.class, KeepAlive::new,
+                    map(0x00, MINECRAFT_1_8),
                     map(0x0B, MINECRAFT_1_9),
                     map(0x0C, MINECRAFT_1_12),
                     map(0x0B, MINECRAFT_1_12_1),
@@ -56,46 +60,56 @@ public enum StateRegistry {
                     map(0x0C, MINECRAFT_1_9),
                     map(0x0C, MINECRAFT_1_12));
             CLIENTBOUND.register(Chat.class, Chat::new,
+                    map(0x02, MINECRAFT_1_8),
                     map(0x0F, MINECRAFT_1_9),
                     map(0x0F, MINECRAFT_1_12),
                     map(0x0E, MINECRAFT_1_13));
             CLIENTBOUND.register(PluginMessage.class, PluginMessage::new,
+                    map(0x3F, MINECRAFT_1_8),
                     map(0x18, MINECRAFT_1_9),
                     map(0x18, MINECRAFT_1_12),
                     map(0x19, MINECRAFT_1_13));
             CLIENTBOUND.register(Disconnect.class, Disconnect::new,
+                    map(0x40, MINECRAFT_1_8),
                     map(0x1A, MINECRAFT_1_9),
                     map(0x1A, MINECRAFT_1_12),
                     map(0x1B, MINECRAFT_1_13));
             CLIENTBOUND.register(KeepAlive.class, KeepAlive::new,
+                    map(0x00, MINECRAFT_1_8),
                     map(0x1F, MINECRAFT_1_9),
                     map(0x1F, MINECRAFT_1_12),
                     map(0x21, MINECRAFT_1_13));
             CLIENTBOUND.register(JoinGame.class, JoinGame::new,
+                    map(0x01, MINECRAFT_1_8),
                     map(0x23, MINECRAFT_1_9),
                     map(0x23, MINECRAFT_1_12),
                     map(0x25, MINECRAFT_1_13));
             CLIENTBOUND.register(Respawn.class, Respawn::new,
+                    map(0x07, MINECRAFT_1_8),
                     map(0x33, MINECRAFT_1_9),
                     map(0x34, MINECRAFT_1_12),
                     map(0x35, MINECRAFT_1_12_2),
                     map(0x38, MINECRAFT_1_13));
             CLIENTBOUND.register(ScoreboardDisplay.class, ScoreboardDisplay::new,
+                    map(0x3D, MINECRAFT_1_8),
                     map(0x38, MINECRAFT_1_9),
                     map(0x3A, MINECRAFT_1_12),
                     map(0x3B, MINECRAFT_1_12_1),
                     map(0x3E, MINECRAFT_1_13));
             CLIENTBOUND.register(ScoreboardObjective.class, ScoreboardObjective::new,
+                    map(0x3B, MINECRAFT_1_8),
                     map(0x3F, MINECRAFT_1_9),
                     map(0x41, MINECRAFT_1_12),
                     map(0x42, MINECRAFT_1_12_1),
                     map(0x45, MINECRAFT_1_13));
             CLIENTBOUND.register(ScoreboardTeam.class, ScoreboardTeam::new,
+                    map(0x3E, MINECRAFT_1_8),
                     map(0x41, MINECRAFT_1_9),
                     map(0x43, MINECRAFT_1_12),
                     map(0x44, MINECRAFT_1_12_1),
                     map(0x47, MINECRAFT_1_13));
             CLIENTBOUND.register(ScoreboardSetScore.class, ScoreboardSetScore::new,
+                    map(0x3C, MINECRAFT_1_8),
                     map(0x42, MINECRAFT_1_9),
                     map(0x44, MINECRAFT_1_12),
                     map(0x45, MINECRAFT_1_12_1),
@@ -266,6 +280,7 @@ public enum StateRegistry {
 
     private static PacketMapping[] genericMappings(int id) {
         return new PacketMapping[]{
+                map(id, MINECRAFT_1_8),
                 map(id, MINECRAFT_1_9),
                 map(id, MINECRAFT_1_12),
                 map(id, MINECRAFT_1_13)

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientSettings.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/ClientSettings.java
@@ -80,7 +80,10 @@ public class ClientSettings implements MinecraftPacket {
         this.chatVisibility = ProtocolUtils.readVarInt(buf);
         this.chatColors = buf.readBoolean();
         this.skinParts = buf.readUnsignedByte();
-        this.mainHand = ProtocolUtils.readVarInt(buf);
+
+        if (protocolVersion >= ProtocolConstants.MINECRAFT_1_9) {
+            this.mainHand = ProtocolUtils.readVarInt(buf);
+        }
     }
 
     @Override
@@ -90,6 +93,9 @@ public class ClientSettings implements MinecraftPacket {
         ProtocolUtils.writeVarInt(buf, chatVisibility);
         buf.writeBoolean(chatColors);
         buf.writeByte(skinParts);
-        ProtocolUtils.writeVarInt(buf, mainHand);
+
+        if (protocolVersion >= ProtocolConstants.MINECRAFT_1_9) {
+            ProtocolUtils.writeVarInt(buf, mainHand);
+        }
     }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGame.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/JoinGame.java
@@ -87,7 +87,11 @@ public class JoinGame implements MinecraftPacket {
     public void decode(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion) {
         this.entityId = buf.readInt();
         this.gamemode = buf.readUnsignedByte();
-        this.dimension = buf.readInt();
+        if (protocolVersion >= ProtocolConstants.MINECRAFT_1_9_1) {
+            this.dimension = buf.readInt();
+        } else {
+            this.dimension = buf.readByte();
+        }
         this.difficulty = buf.readUnsignedByte();
         this.maxPlayers = buf.readUnsignedByte();
         this.levelType = ProtocolUtils.readString(buf, 16);
@@ -98,7 +102,11 @@ public class JoinGame implements MinecraftPacket {
     public void encode(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion) {
         buf.writeInt(entityId);
         buf.writeByte(gamemode);
-        buf.writeInt(dimension);
+        if (protocolVersion >= ProtocolConstants.MINECRAFT_1_9_1) {
+            buf.writeInt(dimension);
+        } else {
+            buf.writeByte(dimension);
+        }
         buf.writeByte(difficulty);
         buf.writeByte(maxPlayers);
         ProtocolUtils.writeString(buf, levelType);


### PR DESCRIPTION
Implemented the 1.8 protocol by reversing the 1.8 to 1.9 changelog on https://wiki.vg/Protocol_History. I have tested this with a variety of different actions/packets and it seems to function correctly. 
Closes #9.