### PR TITLE
Don't handle scoreboards from backend server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,12 @@ modules.xml
 # BlueJ files
 *.ctxt
 
+# Eclipse #
+**/.classpath
+**/.project
+**/.settings/
+**/bin/
+
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 
@@ -123,3 +129,4 @@ gradle-app.setting
 logs/
 /velocity.toml
 server-icon.png
+/bin/

--- a/api/src/main/java/com/velocitypowered/api/proxy/Player.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/Player.java
@@ -30,7 +30,7 @@ public interface Player extends CommandInvoker, InboundConnection {
      * @return an {@link Optional} the server that the player is connected to, which may be empty
      */
     Optional<ServerInfo> getCurrentServer();
-
+    
     /**
      * Sends a chat message to the player's client.
      * @param component the chat message to send

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
@@ -7,7 +7,6 @@ import com.velocitypowered.proxy.protocol.packet.*;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
 import com.velocitypowered.proxy.protocol.util.PluginMessageUtil;
 import io.netty.buffer.ByteBuf;
-import io.netty.util.ReferenceCountUtil;
 
 public class BackendPlaySessionHandler implements MinecraftSessionHandler {
     private final ServerConnection connection;
@@ -35,10 +34,6 @@ public class BackendPlaySessionHandler implements MinecraftSessionHandler {
             connection.getProxyPlayer().handleConnectionException(connection.getServerInfo(), original);
         } else if (packet instanceof JoinGame) {
             playerHandler.handleBackendJoinGame((JoinGame) packet);
-        } else if (packet instanceof Respawn) {
-            // Record the dimension switch, and then forward the packet on.
-            playerHandler.setCurrentDimension(((Respawn) packet).getDimension());
-            connection.getProxyPlayer().getConnection().write(packet);
         } else if (packet instanceof BossBar) {
             BossBar bossBar = (BossBar) packet;
             switch (bossBar.getAction()) {
@@ -64,12 +59,6 @@ public class BackendPlaySessionHandler implements MinecraftSessionHandler {
             connection.getProxyPlayer().getConnection().write(pm);
         } else {
             // Just forward the packet on. We don't have anything to handle at this time.
-            if (packet instanceof ScoreboardTeam ||
-                    packet instanceof ScoreboardObjective ||
-                    packet instanceof ScoreboardSetScore ||
-                    packet instanceof ScoreboardDisplay) {
-                playerHandler.handleServerScoreboardPacket(packet);
-            }
             connection.getProxyPlayer().getConnection().write(packet);
         }
     }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -1,12 +1,6 @@
 package com.velocitypowered.proxy.connection.client;
 
 import com.velocitypowered.proxy.VelocityServer;
-import com.velocitypowered.proxy.command.VelocityCommand;
-import com.velocitypowered.api.server.ServerInfo;
-import com.velocitypowered.proxy.data.scoreboard.Objective;
-import com.velocitypowered.proxy.data.scoreboard.Score;
-import com.velocitypowered.proxy.data.scoreboard.Scoreboard;
-import com.velocitypowered.proxy.data.scoreboard.Team;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
 import com.velocitypowered.proxy.protocol.ProtocolConstants;
 import com.velocitypowered.proxy.protocol.packet.*;
@@ -21,7 +15,6 @@ import net.kyori.text.format.TextColor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.net.InetSocketAddress;
 import java.util.*;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadLocalRandom;
@@ -37,8 +30,6 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
     private boolean spawned = false;
     private final List<UUID> serverBossBars = new ArrayList<>();
     private final Set<String> clientPluginMsgChannels = new HashSet<>();
-    private int currentDimension;
-    private Scoreboard serverScoreboard = new Scoreboard();
     private EntityIdRemapper idRemapper;
 
     public ClientPlaySessionHandler(ConnectedPlayer player) {
@@ -161,7 +152,6 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
         if (!spawned) {
             // nothing special to do here
             spawned = true;
-            currentDimension = joinGame.getDimension();
             player.getConnection().delayedWrite(joinGame);
             idRemapper = EntityIdRemapper.getMapper(joinGame.getEntityId(), player.getConnection().getProtocolVersion());
         } else {
@@ -182,13 +172,6 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
             int tempDim = joinGame.getDimension() == 0 ? -1 : 0;
             player.getConnection().delayedWrite(new Respawn(tempDim, joinGame.getDifficulty(), joinGame.getGamemode(), joinGame.getLevelType()));
             player.getConnection().delayedWrite(new Respawn(joinGame.getDimension(), joinGame.getDifficulty(), joinGame.getGamemode(), joinGame.getLevelType()));
-            currentDimension = joinGame.getDimension();
-        }
-
-        // Resend client settings packet to remote server if we have it, this preserves client settings across
-        // transitions.
-        if (player.getClientSettings() != null) {
-            player.getConnectedServer().getMinecraftConnection().delayedWrite(player.getClientSettings());
         }
 
         // Remove old boss bars.
@@ -199,9 +182,6 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
             player.getConnection().delayedWrite(deletePacket);
         }
         serverBossBars.clear();
-
-        // Remove scoreboard junk.
-        clearServerScoreboard();
 
         // Tell the server about this client's plugin messages. Velocity will forward them on to the client.
         if (!clientPluginMsgChannels.isEmpty()) {
@@ -214,10 +194,6 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
         // Flush everything
         player.getConnection().flush();
         player.getConnectedServer().getMinecraftConnection().flush();
-    }
-
-    public void setCurrentDimension(int currentDimension) {
-        this.currentDimension = currentDimension;
     }
 
     public List<UUID> getServerBossBars() {
@@ -259,86 +235,6 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
 
         // We're going to forward on the original packet.
         player.getConnectedServer().getMinecraftConnection().write(packet);
-    }
-
-    public void handleServerScoreboardPacket(MinecraftPacket packet) {
-        if (packet instanceof ScoreboardDisplay) {
-            ScoreboardDisplay sd = (ScoreboardDisplay) packet;
-            serverScoreboard.setPosition(sd.getPosition());
-            serverScoreboard.setDisplayName(sd.getDisplayName());
-        }
-
-        if (packet instanceof ScoreboardObjective) {
-            ScoreboardObjective so = (ScoreboardObjective) packet;
-            switch (so.getMode()) {
-                case ScoreboardObjective.ADD:
-                    Objective o = new Objective(so.getId());
-                    o.setDisplayName(so.getDisplayName());
-                    o.setType(so.getType());
-                    serverScoreboard.getObjectives().put(so.getId(), o);
-                    break;
-                case ScoreboardObjective.REMOVE:
-                    serverScoreboard.getObjectives().remove(so.getId());
-                    break;
-            }
-        }
-
-        if (packet instanceof ScoreboardSetScore) {
-            ScoreboardSetScore sss = (ScoreboardSetScore) packet;
-            Objective objective = serverScoreboard.getObjectives().get(sss.getObjective());
-            if (objective == null) {
-                return;
-            }
-            switch (sss.getAction()) {
-                case ScoreboardSetScore.CHANGE:
-                    Score score = new Score(sss.getEntity(), sss.getValue());
-                    objective.getScores().put(sss.getEntity(), score);
-                    break;
-                case ScoreboardSetScore.REMOVE:
-                    objective.getScores().remove(sss.getEntity());
-                    break;
-            }
-        }
-
-        if (packet instanceof ScoreboardTeam) {
-            ScoreboardTeam st = (ScoreboardTeam) packet;
-            switch (st.getMode()) {
-                case ScoreboardTeam.ADD:
-                    // TODO: Preserve other team information? We might not need to...
-                    Team team = new Team(st.getId());
-                    serverScoreboard.getTeams().put(st.getId(), team);
-                    break;
-                case ScoreboardTeam.REMOVE:
-                    serverScoreboard.getTeams().remove(st.getId());
-                    break;
-            }
-        }
-    }
-
-    private void clearServerScoreboard() {
-        for (Objective objective : serverScoreboard.getObjectives().values()) {
-            for (Score score : objective.getScores().values()) {
-                ScoreboardSetScore sss = new ScoreboardSetScore();
-                sss.setObjective(objective.getId());
-                sss.setAction(ScoreboardSetScore.REMOVE);
-                sss.setEntity(score.getTarget());
-                player.getConnection().delayedWrite(sss);
-            }
-
-            ScoreboardObjective so = new ScoreboardObjective();
-            so.setId(objective.getId());
-            so.setMode(ScoreboardObjective.REMOVE);
-            player.getConnection().delayedWrite(so);
-        }
-
-        for (Team team : serverScoreboard.getTeams().values()) {
-            ScoreboardTeam st = new ScoreboardTeam();
-            st.setId(team.getId());
-            st.setMode(ScoreboardTeam.REMOVE);
-            player.getConnection().delayedWrite(st);
-        }
-
-        serverScoreboard = new Scoreboard();
     }
 
     public Set<String> getClientPluginMsgChannels() {

--- a/proxy/src/test/java/com/velocitypowered/proxy/protocol/PacketRegistryTest.java
+++ b/proxy/src/test/java/com/velocitypowered/proxy/protocol/PacketRegistryTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class PacketRegistryTest {
     private StateRegistry.PacketRegistry setupRegistry() {
         StateRegistry.PacketRegistry registry = new StateRegistry.PacketRegistry(ProtocolConstants.Direction.CLIENTBOUND, StateRegistry.HANDSHAKE);
-        registry.register(Handshake.class, Handshake::new, new StateRegistry.PacketMapping(0x00, MINECRAFT_1_12));
+        registry.register(Handshake.class, Handshake::new, new StateRegistry.PacketMapping(0x00, MINECRAFT_1_12, true));
         return registry;
     }
 
@@ -44,8 +44,8 @@ class PacketRegistryTest {
     @Test
     void registrySuppliesCorrectPacketsByProtocol() {
         StateRegistry.PacketRegistry registry = new StateRegistry.PacketRegistry(ProtocolConstants.Direction.CLIENTBOUND, StateRegistry.HANDSHAKE);
-        registry.register(Handshake.class, Handshake::new, new StateRegistry.PacketMapping(0x00, MINECRAFT_1_12),
-                new StateRegistry.PacketMapping(0x01, MINECRAFT_1_12_1));
+        registry.register(Handshake.class, Handshake::new, new StateRegistry.PacketMapping(0x00, MINECRAFT_1_12, true),
+                new StateRegistry.PacketMapping(0x01, MINECRAFT_1_12_1, true));
         assertEquals(Handshake.class, registry.getVersion(MINECRAFT_1_12).createPacket(0x00).getClass());
         assertEquals(Handshake.class, registry.getVersion(MINECRAFT_1_12_1).createPacket(0x01).getClass());
         assertEquals(Handshake.class, registry.getVersion(MINECRAFT_1_12_2).createPacket(0x01).getClass());


### PR DESCRIPTION
When player switch a server, velocity sends a login packet and when client receive packet it creates a new playerController/worldController objects where client store all scoreboards. We dont need to store scoreboards in memory.

Tested on MC 1.8.9, 1.12.2 and 1.13.