### PR TITLE
Permissions!

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/command/CommandSource.java
+++ b/api/src/main/java/com/velocitypowered/api/command/CommandSource.java
@@ -1,22 +1,16 @@
 package com.velocitypowered.api.command;
 
+import com.velocitypowered.api.permission.PermissionSubject;
 import net.kyori.text.Component;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * Represents something that can be used to run a {@link Command}.
  */
-public interface CommandSource {
+public interface CommandSource extends PermissionSubject {
     /**
      * Sends the specified {@code component} to the invoker.
      * @param component the text component to send
      */
     void sendMessage(@NonNull Component component);
-
-    /**
-     * Determines whether or not the invoker has a particular permission.
-     * @param permission the permission to check for
-     * @return whether or not the invoker has permission to run this command
-     */
-    boolean hasPermission(@NonNull String permission);
 }

--- a/api/src/main/java/com/velocitypowered/api/event/EventManager.java
+++ b/api/src/main/java/com/velocitypowered/api/event/EventManager.java
@@ -30,7 +30,7 @@ public interface EventManager {
      * @param event the event to fire
      * @return a {@link CompletableFuture} representing the posted event
      */
-    @NonNull CompletableFuture<Object> fire(@NonNull Object event);
+    @NonNull <E> CompletableFuture<E> fire(@NonNull E event);
 
     /**
      * Posts the specified event to the event bus and discards the result.

--- a/api/src/main/java/com/velocitypowered/api/event/permission/PermissionsSetupEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/permission/PermissionsSetupEvent.java
@@ -1,0 +1,55 @@
+package com.velocitypowered.api.event.permission;
+
+import com.google.common.base.Preconditions;
+import com.velocitypowered.api.permission.PermissionFunction;
+import com.velocitypowered.api.permission.PermissionProvider;
+import com.velocitypowered.api.permission.PermissionSubject;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Called when a {@link PermissionSubject}'s permissions are being setup.
+ *
+ * <p>This event is only called once per subject, on initialisation.</p>
+ */
+public class PermissionsSetupEvent {
+    private final PermissionSubject subject;
+    private final PermissionProvider defaultProvider;
+    private PermissionProvider provider;
+
+    public PermissionsSetupEvent(PermissionSubject subject, PermissionProvider provider) {
+        this.subject = Preconditions.checkNotNull(subject, "subject");
+        this.provider = this.defaultProvider = Preconditions.checkNotNull(provider, "provider");
+    }
+
+    public @NonNull PermissionSubject getSubject() {
+        return this.subject;
+    }
+
+    /**
+     * Uses the provider function to obtain a {@link PermissionFunction} for
+     * the subject.
+     *
+     * @param subject the subject
+     * @return the obtained permission function
+     */
+    public @NonNull PermissionFunction createFunction(PermissionSubject subject) {
+        return this.provider.createFunction(subject);
+    }
+
+    public @NonNull PermissionProvider getProvider() {
+        return this.provider;
+    }
+
+    /**
+     * Sets the {@link PermissionFunction} that should be used for the subject.
+     *
+     * <p>Specifying <code>null</code> will reset the provider to the default
+     * instance given when the event was posted.</p>
+     *
+     * @param provider the provider
+     */
+    public void setProvider(@Nullable PermissionProvider provider) {
+        this.provider = provider == null ? this.defaultProvider : provider;
+    }
+}

--- a/api/src/main/java/com/velocitypowered/api/permission/PermissionFunction.java
+++ b/api/src/main/java/com/velocitypowered/api/permission/PermissionFunction.java
@@ -1,0 +1,33 @@
+package com.velocitypowered.api.permission;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Function that calculates the permission settings for a given
+ * {@link PermissionSubject}.
+ */
+@FunctionalInterface
+public interface PermissionFunction {
+    /**
+     * A permission function that always returns {@link Tristate#TRUE}.
+     */
+    PermissionFunction ALWAYS_TRUE = p -> Tristate.TRUE;
+
+    /**
+     * A permission function that always returns {@link Tristate#FALSE}.
+     */
+    PermissionFunction ALWAYS_FALSE = p -> Tristate.FALSE;
+
+    /**
+     * A permission function that always returns {@link Tristate#UNDEFINED}.
+     */
+    PermissionFunction ALWAYS_UNDEFINED = p -> Tristate.UNDEFINED;
+
+    /**
+     * Gets the subjects setting for a particular permission.
+     *
+     * @param permission the permission
+     * @return the value the permission is set to
+     */
+    @NonNull Tristate getPermissionSetting(@NonNull String permission);
+}

--- a/api/src/main/java/com/velocitypowered/api/permission/PermissionProvider.java
+++ b/api/src/main/java/com/velocitypowered/api/permission/PermissionProvider.java
@@ -1,0 +1,17 @@
+package com.velocitypowered.api.permission;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Provides {@link PermissionFunction}s for {@link PermissionSubject}s.
+ */
+@FunctionalInterface
+public interface PermissionProvider {
+    /**
+     * Creates a {@link PermissionFunction} for the subject.
+     *
+     * @param subject the subject
+     * @return the function
+     */
+    @NonNull PermissionFunction createFunction(@NonNull PermissionSubject subject);
+}

--- a/api/src/main/java/com/velocitypowered/api/permission/PermissionSubject.java
+++ b/api/src/main/java/com/velocitypowered/api/permission/PermissionSubject.java
@@ -1,0 +1,16 @@
+package com.velocitypowered.api.permission;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Represents a object that has a set of queryable permissions.
+ */
+public interface PermissionSubject {
+    /**
+     * Determines whether or not the subject has a particular permission.
+     *
+     * @param permission the permission to check for
+     * @return whether or not the subject has the permission
+     */
+    boolean hasPermission(@NonNull String permission);
+}

--- a/api/src/main/java/com/velocitypowered/api/permission/Tristate.java
+++ b/api/src/main/java/com/velocitypowered/api/permission/Tristate.java
@@ -1,0 +1,74 @@
+package com.velocitypowered.api.permission;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Represents three different states of a setting.
+ *
+ * <p>Possible values:</p>
+ * <p></p>
+ * <ul>
+ *     <li>{@link #TRUE} - a positive setting</li>
+ *     <li>{@link #FALSE} - a negative (negated) setting</li>
+ *     <li>{@link #UNDEFINED} - a non-existent setting</li>
+ * </ul>
+ */
+public enum Tristate {
+
+    /**
+     * A value indicating a positive setting
+     */
+    TRUE(true),
+
+    /**
+     * A value indicating a negative (negated) setting
+     */
+    FALSE(false),
+
+    /**
+     * A value indicating a non-existent setting
+     */
+    UNDEFINED(false);
+
+    /**
+     * Returns a {@link Tristate} from a boolean
+     *
+     * @param val the boolean value
+     * @return {@link #TRUE} or {@link #FALSE}, if the value is <code>true</code> or <code>false</code>, respectively.
+     */
+    public static @NonNull Tristate fromBoolean(boolean val) {
+        return val ? TRUE : FALSE;
+    }
+
+    /**
+     * Returns a {@link Tristate} from a nullable boolean.
+     *
+     * <p>Unlike {@link #fromBoolean(boolean)}, this method returns {@link #UNDEFINED}
+     * if the value is null.</p>
+     *
+     * @param val the boolean value
+     * @return {@link #UNDEFINED}, {@link #TRUE} or {@link #FALSE}, if the value
+     *         is <code>null</code>, <code>true</code> or <code>false</code>, respectively.
+     */
+    public static @NonNull Tristate fromNullableBoolean(@Nullable Boolean val) {
+        return val == null ? UNDEFINED : val ? TRUE : FALSE;
+    }
+
+    private final boolean booleanValue;
+
+    Tristate(boolean booleanValue) {
+        this.booleanValue = booleanValue;
+    }
+
+    /**
+     * Returns the value of the Tristate as a boolean.
+     *
+     * <p>A value of {@link #UNDEFINED} converts to false.</p>
+     *
+     * @return a boolean representation of the Tristate.
+     */
+    public boolean asBoolean() {
+        return this.booleanValue;
+    }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -2,6 +2,8 @@ package com.velocitypowered.proxy.connection.client;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;
+import com.velocitypowered.api.permission.PermissionFunction;
+import com.velocitypowered.api.permission.PermissionProvider;
 import com.velocitypowered.api.proxy.ConnectionRequestBuilder;
 import com.velocitypowered.api.util.MessagePosition;
 import com.velocitypowered.api.proxy.Player;
@@ -35,12 +37,14 @@ import java.util.concurrent.CompletableFuture;
 
 public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
     private static final PlainComponentSerializer PASS_THRU_TRANSLATE = new PlainComponentSerializer((c) -> "", TranslatableComponent::key);
+    public static final PermissionProvider DEFAULT_PERMISSIONS = s -> PermissionFunction.ALWAYS_UNDEFINED;
 
     private static final Logger logger = LogManager.getLogger(ConnectedPlayer.class);
 
     private final GameProfile profile;
     private final MinecraftConnection connection;
     private final InetSocketAddress virtualHost;
+    private PermissionFunction permissionFunction = null;
     private int tryIndex = 0;
     private ServerConnection connectedServer;
     private ClientSettings clientSettings;
@@ -83,6 +87,10 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
     @Override
     public Optional<InetSocketAddress> getVirtualHost() {
         return Optional.ofNullable(virtualHost);
+    }
+
+    public void setPermissionFunction(PermissionFunction permissionFunction) {
+        this.permissionFunction = permissionFunction;
     }
 
     @Override
@@ -230,7 +238,7 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
 
     @Override
     public boolean hasPermission(@Nonnull String permission) {
-        return false; // TODO: Implement permissions.
+        return permissionFunction.getPermissionSetting(permission).asBoolean();
     }
 
     private class ConnectionRequestBuilderImpl implements ConnectionRequestBuilder {

--- a/proxy/src/main/java/com/velocitypowered/proxy/plugin/VelocityEventManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/plugin/VelocityEventManager.java
@@ -59,14 +59,14 @@ public class VelocityEventManager implements EventManager {
     }
 
     @Override
-    public @NonNull CompletableFuture<Object> fire(@NonNull Object event) {
+    public <E> @NonNull CompletableFuture<E> fire(@NonNull E event) {
         Preconditions.checkNotNull(event, "event");
         if (!bus.hasSubscribers(event.getClass())) {
             // Optimization: nobody's listening.
             return CompletableFuture.completedFuture(event);
         }
 
-        CompletableFuture<Object> eventFuture = new CompletableFuture<>();
+        CompletableFuture<E> eventFuture = new CompletableFuture<>();
         service.execute(() -> {
             PostResult result = bus.post(event);
             if (!result.exceptions().isEmpty()) {


### PR DESCRIPTION
My aims with this were, in no particular order:

* Easy/simple to use
* Straight forward to implement, delegating *all* handling to the plugin managing permissions
* Fast in terms of performance

I've borrowed a few concepts from other areas of the MC ecosystem, namely

* `Tristate` from [Sponge](https://github.com/SpongePowered/SpongeAPI/blob/stable-7/src/main/java/org/spongepowered/api/util/Tristate.java) & [LuckPerms](https://github.com/lucko/LuckPerms/blob/master/api/src/main/java/me/lucko/luckperms/api/Tristate.java).

* `PermissionSubject` from [Sponge](https://github.com/SpongePowered/SpongeAPI/blob/stable-7/src/main/java/org/spongepowered/api/service/permission/Subject.java), although only the name is copied. The interface is really just a simple version of Bukkit's `Permissible`.

* `PermissionFunction` fulfils the same purpose as Bukkit's `PermissibleBase`, except it's not an implementation. It allows other plugins to effectively implement a `PermissionSubject`'s hasPermission method.


Design choices:

* Why not just an event? Well, mainly performance reasons. Permission checks should be fast, and creating, scheduling and then joining a future isn't exactly fast, especially in comparison with just doing a direct call to the provider. Additionally, doing things this way allows providers to store a players permissions data directly on the provider instance, as opposed to doing map lookups.


Potential issues:

* If support for reloading individual plugins was ever implemented, we'd probably have to re-think the way plugin provided "services" are handled.